### PR TITLE
add feature flag for fixed wind data mode and enable on VL3

### DIFF
--- a/community-vl3rotax915/SimObjects/Airplanes/Asobo_VL3_915/panel/panel.xml
+++ b/community-vl3rotax915/SimObjects/Airplanes/Asobo_VL3_915/panel/panel.xml
@@ -3,6 +3,7 @@
 		<Name>AS3X_Touch_1</Name>
 		<SyntheticVision>True</SyntheticVision>
 		<AltimeterIndex>0</AltimeterIndex>
+		<WindDataMode>1</WindDataMode>
 		<!-- DisplayMode>PFD</DisplayMode> -->
 		<ReversionaryMode>True</ReversionaryMode>
 		<Electric>

--- a/community-vl3rotax915/layout.json
+++ b/community-vl3rotax915/layout.json
@@ -2,728 +2,728 @@
   "content": [
     {
       "path": "de-DE.locPak",
-      "size": 1524,
-      "date": 132460516883404959
+      "size": 1514,
+      "date": 132463154140573161
     },
     {
       "path": "en-US.locPak",
-      "size": 1323,
-      "date": 132460516883404959
+      "size": 1313,
+      "date": 132463154140613123
     },
     {
       "path": "es-ES.locPak",
-      "size": 1503,
-      "date": 132460516883409961
+      "size": 1493,
+      "date": 132463154140642824
     },
     {
       "path": "fr-FR.locPak",
-      "size": 1480,
-      "date": 132460516883409961
+      "size": 1470,
+      "date": 132463154140683286
     },
     {
       "path": "it-IT.locPak",
-      "size": 1493,
-      "date": 132460516883414961
+      "size": 1483,
+      "date": 132463154141300896
     },
     {
       "path": "pl-PL.locPak",
-      "size": 1371,
-      "date": 132460516883419960
+      "size": 1361,
+      "date": 132463154141398110
     },
     {
       "path": "pt-BR.locPak",
-      "size": 1403,
-      "date": 132460516883424960
+      "size": 1393,
+      "date": 132463154141428062
     },
     {
       "path": "ru-RU.locPak",
-      "size": 2141,
-      "date": 132460516883424960
+      "size": 2131,
+      "date": 132463154141467831
     },
     {
       "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/AS3X_Touch.css",
-      "size": 94440,
-      "date": 132462017499656281
+      "size": 92084,
+      "date": 132463154140760520
     },
     {
       "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/AS3X_Touch.html",
       "size": 83291,
-      "date": 132462017499661286
+      "date": 132463154140820525
     },
     {
       "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/AS3X_Touch.js",
       "size": 58727,
-      "date": 132462017499666283
+      "date": 132463154140920818
     },
     {
       "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/AS3X_Touch/mapConfig.json",
       "size": 3578,
-      "date": 132462017499671281
+      "date": 132463154141040815
     },
     {
       "path": "html_ui/Pages/VCockpit/Instruments/NavSystems/Shared/CommonPFD_MFD.js",
-      "size": 188306,
-      "date": 132462017499681280
+      "size": 189326,
+      "date": 132463199371980117
     },
     {
       "path": "RTC/Asobo_VL3_915/RTC_Hangar.spb",
       "size": 1676,
-      "date": 132460516867514961
+      "date": 132463154124989664
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/ai.cfg",
-      "size": 747,
-      "date": 132460516897164962
+      "size": 721,
+      "date": 132463154133980483
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/aircraft.cfg",
-      "size": 4822,
-      "date": 132460516877414960
+      "size": 4714,
+      "date": 132463154134020192
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/aircraft.loc",
-      "size": 14134,
-      "date": 132460516877419961
+      "size": 14004,
+      "date": 132463154134070485
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/Approach.flt",
-      "size": 2695,
-      "date": 132460516907909960
+      "size": 2551,
+      "date": 132463154125039737
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/apron.flt",
-      "size": 2757,
-      "date": 132460516897154962
+      "size": 2607,
+      "date": 132463154134110480
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/cameras.cfg",
-      "size": 16338,
-      "date": 132460516897144970
+      "size": 15550,
+      "date": 132463154134148296
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/Climb.flt",
-      "size": 2699,
-      "date": 132460516907904960
+      "size": 2554,
+      "date": 132463154125078282
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/cockpit.cfg",
-      "size": 5178,
-      "date": 132460516897124961
+      "size": 4825,
+      "date": 132463154134273696
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/Cruise.flt",
-      "size": 2695,
-      "date": 132460516907894961
+      "size": 2551,
+      "date": 132463154125108352
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/engines.cfg",
-      "size": 11190,
-      "date": 132460516897114962
+      "size": 11053,
+      "date": 132463154134313391
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/Final.flt",
-      "size": 2696,
-      "date": 132460516907889959
+      "size": 2552,
+      "date": 132463154125118352
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/flight_model.cfg",
-      "size": 16120,
-      "date": 132462017499631262
+      "size": 15817,
+      "date": 132463154134363717
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/gameplay.cfg",
-      "size": 1275,
-      "date": 132460516897104962
+      "size": 1238,
+      "date": 132463154134403688
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/hangar.flt",
-      "size": 2630,
-      "date": 132460516897094961
+      "size": 2488,
+      "date": 132463154134433397
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/runway.FLT",
-      "size": 2708,
-      "date": 132460516897044960
+      "size": 2560,
+      "date": 132463154136600018
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/systems.cfg",
-      "size": 7794,
-      "date": 132460516897039960
+      "size": 7667,
+      "date": 132463154140353169
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/target_performance.cfg",
-      "size": 1639,
-      "date": 132460516897029960
+      "size": 1583,
+      "date": 132463154140392795
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/taxi.flt",
-      "size": 2683,
-      "date": 132460516897024960
+      "size": 2536,
+      "date": 132463154140443179
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/checklist/Library.xml",
-      "size": 1782,
-      "date": 132460516897139967
+      "size": 1739,
+      "date": 132463154134193703
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/checklist/VL3_Checklist.xml",
-      "size": 3959,
-      "date": 132460516897129960
+      "size": 3849,
+      "date": 132463154134233717
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/model.CFG",
-      "size": 664,
-      "date": 132460516897069960
+      "size": 650,
+      "date": 132463154136470427
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3.xml",
-      "size": 3631,
-      "date": 132460516897089966
+      "size": 3547,
+      "date": 132463154134483406
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit.xml",
-      "size": 13560,
-      "date": 132460516897079972
+      "size": 13222,
+      "date": 132463154135573565
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod0.bin",
       "size": 5012480,
-      "date": 132460516878754961
+      "date": 132463154135817692
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod0.gltf",
-      "size": 288229,
-      "date": 132460516878764961
+      "size": 288228,
+      "date": 132463154135827685
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod1.bin",
       "size": 3201536,
-      "date": 132460516878954960
+      "date": 132463154135997404
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod1.gltf",
-      "size": 269726,
-      "date": 132460516878964960
+      "size": 269725,
+      "date": 132463154136017739
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod2.bin",
       "size": 1825408,
-      "date": 132460516879074963
+      "date": 132463154136127398
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod2.gltf",
-      "size": 213319,
-      "date": 132460516879079962
+      "size": 213318,
+      "date": 132463154136147410
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod3.bin",
       "size": 1019264,
-      "date": 132460516879144961
+      "date": 132463154136234301
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod3.gltf",
-      "size": 185297,
-      "date": 132460516879149960
+      "size": 185296,
+      "date": 132463154136244297
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod4.bin",
       "size": 409088,
-      "date": 132460516879174959
+      "date": 132463154136304593
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod4.gltf",
-      "size": 141039,
-      "date": 132460516879179962
+      "size": 141038,
+      "date": 132463154136314315
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod5.bin",
       "size": 32640,
-      "date": 132460516879184962
+      "date": 132463154136364318
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod5.gltf",
-      "size": 53771,
-      "date": 132460516879184962
+      "size": 53770,
+      "date": 132463154136374597
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod6.bin",
       "size": 11392,
-      "date": 132460516879189960
+      "date": 132463154136414316
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_cockpit_lod6.gltf",
-      "size": 38305,
-      "date": 132460516879194962
+      "size": 38304,
+      "date": 132463154136424298
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD00.bin",
       "size": 6237312,
-      "date": 132460516877834962
+      "date": 132463154134793541
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD00.gltf",
-      "size": 116344,
-      "date": 132460516877864960
+      "size": 116343,
+      "date": 132463154134823538
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD01.bin",
       "size": 4409984,
-      "date": 132460516878129961
+      "date": 132463154135053832
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD01.gltf",
-      "size": 121201,
-      "date": 132460516878144961
+      "size": 121200,
+      "date": 132463154135063830
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD02.bin",
       "size": 2791552,
-      "date": 132460516878309961
+      "date": 132463154135223544
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD02.gltf",
-      "size": 121051,
-      "date": 132460516878314960
+      "size": 121050,
+      "date": 132463154135233964
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD03.bin",
       "size": 978944,
-      "date": 132460516878374961
+      "date": 132463154135313872
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD03.gltf",
-      "size": 118050,
-      "date": 132460516878379961
+      "size": 118049,
+      "date": 132463154135323561
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD04.bin",
       "size": 650240,
-      "date": 132460516878419962
+      "date": 132463154135393545
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD04.gltf",
-      "size": 116768,
-      "date": 132460516878424960
+      "size": 116767,
+      "date": 132463154135413558
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD05.bin",
       "size": 422016,
-      "date": 132460516878439960
+      "date": 132463154135453568
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD05.gltf",
-      "size": 104105,
-      "date": 132460516878444961
+      "size": 104104,
+      "date": 132463154135473934
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD06.bin",
       "size": 178560,
-      "date": 132460516878454959
+      "date": 132463154135523550
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/model/VL3_LOD06.gltf",
-      "size": 23853,
-      "date": 132460516878459959
+      "size": 23852,
+      "date": 132463154135533983
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/panel/PANEL.CFG",
-      "size": 1069,
-      "date": 132460516897059960
+      "size": 1027,
+      "date": 132463154136520338
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/panel/panel.xml",
-      "size": 9885,
-      "date": 132462028510679540
+      "size": 15192,
+      "date": 132463196654392437
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/sound/Asobo_VL3.PC.PCK",
       "size": 88499434,
-      "date": 132460516882869960
+      "date": 132463154139807372
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/sound/sound.xml",
-      "size": 20783,
-      "date": 132460516882904960
+      "size": 20475,
+      "date": 132463154139897392
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/soundai/Asobo_VL3_AI.PC.PCK",
       "size": 10160750,
-      "date": 132460516883379960
+      "date": 132463154140272799
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/soundai/soundai.xml",
-      "size": 2695,
-      "date": 132460516883389960
+      "size": 2657,
+      "date": 132463154140303123
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DECALS_ALBD.PNG.DDS",
       "size": 1398276,
-      "date": 132460516907169960
+      "date": 132463154129442704
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DECALS_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516907129960
+      "date": 132463154129472698
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DETAILS_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516906844958
+      "date": 132463154129722685
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DETAILS_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516906499960
+      "date": 132463154129752689
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DETAILS_COMP.PNG.DDS",
       "size": 5592580,
-      "date": 132460516906204960
+      "date": 132463154130042683
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_DETAILS_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516905799960
+      "date": 132463154130082697
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_FUSELAGE_ALBD.PNG.DDS",
       "size": 22369796,
-      "date": 132460516904739960
+      "date": 132463154130626329
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_FUSELAGE_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516873619960
+      "date": 132463154130691441
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_FUSELAGE_COMP.PNG.DDS",
       "size": 22369796,
-      "date": 132460516902809960
+      "date": 132463154131427085
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_FUSELAGE_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516874839960
+      "date": 132463154131468627
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_LIVERY_ALBD.PNG.DDS",
       "size": 1540,
-      "date": 132460516901589966
+      "date": 132463154131478898
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_LIVERY_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516874849959
+      "date": 132463154131508620
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_LIVERY_DECALS_ALBD.PNG.DDS",
       "size": 349700,
-      "date": 132460516901569959
+      "date": 132463154131562208
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_LIVERY_DECALS_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516874859961
+      "date": 132463154131591963
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_BLURRED_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516901294961
+      "date": 132463154131752198
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_BLURRED_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516875119959
+      "date": 132463154131781949
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_BLURRED_SIDE.PNG.DDS",
       "size": 43940,
-      "date": 132460516901034966
+      "date": 132463154131797685
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_BLURRED_SIDE.PNG.DDS.json",
       "size": 119,
-      "date": 132460516901024961
+      "date": 132463154131847753
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_SLOW_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516900739961
+      "date": 132463154132070922
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_SLOW_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516875449960
+      "date": 132463154132100674
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_STILL_ALBD.PNG.DDS",
       "size": 1398276,
-      "date": 132460516900349959
+      "date": 132463154132146312
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_STILL_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516875514966
+      "date": 132463154132186303
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_STILL_COMP.PNG.DDS",
       "size": 1398276,
-      "date": 132460516900219960
+      "date": 132463154132256300
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_PROP_STILL_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516900114961
+      "date": 132463154132296567
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_WINGS_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516899859966
+      "date": 132463154132466307
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_WINGS_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516875869960
+      "date": 132463154132506630
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_WINGS_COMP.PNG.DDS",
       "size": 5592580,
-      "date": 132460516899354965
+      "date": 132463154132846606
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_AIRFRAME_WINGS_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516876119960
+      "date": 132463154132886528
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_DECALS_ALBD.TIF.DDS",
       "size": 1398276,
-      "date": 132460516899034960
+      "date": 132463154132936314
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_DECALS_ALBD.TIF.DDS.json",
       "size": 119,
-      "date": 132460516876189959
+      "date": 132463154132966600
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_FLOOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516898694961
+      "date": 132463154133136940
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_FLOOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516876459960
+      "date": 132463154133176478
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_MAIN_INTERIOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516898139960
+      "date": 132463154133406199
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_MAIN_INTERIOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516876799959
+      "date": 132463154133446207
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_SEATS_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516897529983
+      "date": 132463154133650862
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_SEATS_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516877109960
+      "date": 132463154133700178
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_SECONDARY_INTERIOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516877384961
+      "date": 132463154133850187
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/JMB_VL3_COCKPIT_SECONDARY_INTERIOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516877394960
+      "date": 132463154133890483
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/texture.CFG",
-      "size": 378,
-      "date": 132462028510674541
+      "size": 367,
+      "date": 132463154133900499
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/thumbnail.JPG",
       "size": 72014,
-      "date": 132460516897184961
+      "date": 132463154133920178
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE/thumbnail_small.JPG",
       "size": 27523,
-      "date": 132460516897174961
+      "date": 132463154133950480
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_FUSELAGE_ALBD.PNG.DDS",
       "size": 22369796,
-      "date": 132460516868189960
+      "date": 132463154125675595
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_FUSELAGE_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907879961
+      "date": 132463154125725619
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_FUSELAGE_COMP.PNG.DDS",
       "size": 22369796,
-      "date": 132460516869499958
+      "date": 132463154126794396
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_FUSELAGE_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516907874962
+      "date": 132463154126834133
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_LIVERY_ALBD.PNG.DDS",
       "size": 5592560,
-      "date": 132460516869619961
+      "date": 132463154126934418
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_LIVERY_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907864961
+      "date": 132463154126964143
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_LIVERY_DECALS_ALBD.PNG.DDS",
       "size": 349680,
-      "date": 132460516869639971
+      "date": 132463154127014126
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_LIVERY_DECALS_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516907859962
+      "date": 132463154127054140
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_BLURRED_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516870024961
+      "date": 132463154127374135
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_BLURRED_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516907849967
+      "date": 132463154127404366
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_SLOW_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516870209960
+      "date": 132463154127474120
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_SLOW_ALBD.PNG.DDS.json",
       "size": 119,
-      "date": 132460516907844960
+      "date": 132463154127514131
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_STILL_ALBD.PNG.DDS",
       "size": 1398256,
-      "date": 132460516870259961
+      "date": 132463154127577276
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_PROP_STILL_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907834960
+      "date": 132463154127615555
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_WINGS_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516870439961
+      "date": 132463154127735917
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_WINGS_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907829960
+      "date": 132463154127775619
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_WINGS_COMP.PNG.DDS",
       "size": 5592580,
-      "date": 132460516870789960
+      "date": 132463154128015966
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_AIRFRAME_WINGS_COMP.PNG.DDS.json",
       "size": 191,
-      "date": 132460516907819960
+      "date": 132463154128055901
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_DECALS_ALBD.TIF.DDS",
       "size": 1398276,
-      "date": 132460516870859963
+      "date": 132463154128125614
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_DECALS_ALBD.TIF.DDS.json",
       "size": 119,
-      "date": 132460516907814961
+      "date": 132463154128165627
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_FLOOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516871104963
+      "date": 132463154128518714
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_FLOOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907809970
+      "date": 132463154128548701
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_MAIN_INTERIOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516871394961
+      "date": 132463154128779118
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_MAIN_INTERIOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907799961
+      "date": 132463154128808238
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_SEATS_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516871659965
+      "date": 132463154129003364
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_SEATS_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907794968
+      "date": 132463154129038118
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_SECONDARY_INTERIOR_ALBD.PNG.DDS",
       "size": 5592580,
-      "date": 132460516907529960
+      "date": 132463154129227817
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/JMB_VL3_COCKPIT_SECONDARY_INTERIOR_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132460516907234961
+      "date": 132463154129257834
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/texture.CFG",
-      "size": 378,
-      "date": 132462028510669541
+      "size": 367,
+      "date": 132463154129294530
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/thumbnail.JPG",
       "size": 431601,
-      "date": 132460516871949962
+      "date": 132463154129338635
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/TEXTURE.REDHAWKE/thumbnail_small.JPG",
       "size": 78679,
-      "date": 132460516871954970
+      "date": 132463154129380605
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/texture.shared/JMB_VL3_COCKPIT_AIRSPEED_ALBD.PNG.DDS",
       "size": 263296,
-      "date": 132462028510694516
+      "date": 132463154140492813
     },
     {
       "path": "SimObjects/Airplanes/Asobo_VL3_915/texture.shared/JMB_VL3_COCKPIT_AIRSPEED_ALBD.PNG.DDS.json",
       "size": 102,
-      "date": 132462028510699541
+      "date": 132463154140543103
     }
   ]
 }


### PR DESCRIPTION
Hi!   I found this mod from someone on the Bush League Legends discord.  They were concerned about whether it would  conflict with the Working Title G3X Touch I'm developing for them.   At first I didn't think an engine mod would, but then I noticed you were also altering avionics, including `CommonPFD_MFD.js`.

The way this mod is written it will break the wind data bug of every plane that uses the stock `CommonPFD_MFD.js` -- which means everything using the stock G1000 in addition to whatever use is modified to use it.   (It turns out it wouldn't break the Working Title mods because we put stuff into our own directories for just that reason, but not everyone uses the WT G1000).

This PR creates a feature flag that can be set in a plane's panel.xml to force a given wind data mode, and then adds it to your modded VL3.   This will allow you to have the feature that you want without breaking wind data for everything else.  This is the way that Asobo themselves turn various things such as synthetic vision on and off within a glass display.  I also threw in some of the logic we have in the Working Title avionics to correct the way wind data is displayed when you're on the ground for free.  :D 

As a side note:  do you really want this particular plane to be forced to mode 1?   Or was that just meant to get something to show up quickly?    If it's the latter, you might want to think about pulling the avionics out of this entirely and suggesting that people try the Working Title G3X package.  It adds the wind data bug, too, but it also creates a configuration menu item for it so people can select their mode.   With a small modification I'm going to make soon it will also take advantage of the Working Title preference persistence system to peoples favorite mode stays set between sessions.

(The WT G3X also does a little bit of restyling to closer match the real thing, puts the CAS alert system where it should be, and includes support for an optional auto-regulated pitot heater. I'm not sure if the VL3 has this in real life, but it's configurable via a feature flag just like I've set up here for your wind data.  Very soon there will be NEXRAD support, too.)

The G3X is currently in alpha mode, meaning it isn't anywhere close to feature complete, but it's already being used by the BLL guys who appreciate the enhancements.

Either way, even if you're not interested in having folks use that and want to keep your own avionics, this patch will give you a politer way of doing it.  :)

I hope this helps!

If you want to try out the WT G3X for yourself the code is [here](https://github.com/Working-Title-MSFS-Mods/fspackages/tree/feature/gx/src/workingtitle-vcockpits-instruments-navsystems-gx), but since it uses our build system that directory won't be complete on its own.  You might find it easier to just grab a compiled package.   Here's the latest alpha build:

[workingtitle-gx-alpha3.zip](https://github.com/r9r-dev/fs2020-vl3-rotax915/files/5324537/workingtitle-gx-alpha3.zip)

(This is also fully compatible with the Working Title G1000 if you use that.)